### PR TITLE
Fixing the isFinite method for now

### DIFF
--- a/specs/java/lang/Double.jml
+++ b/specs/java/lang/Double.jml
@@ -66,17 +66,13 @@ public /*@ pure @*/ final class Double extends Number implements Comparable {
     @*/
     
     public static final double POSITIVE_INFINITY;
-    //@ axiom \forall double d;; !isNaN(d) ==> d <= POSITIVE_INFINITY;
 
     public static final double NEGATIVE_INFINITY;
-    //@ axiom \forall double d;; !isNaN(d) ==> d >= NEGATIVE_INFINITY;
 
     public static final double NaN;
 
-    public static final double MAX_VALUE;
-    //@ axiom MAX_VALUE == 0x1.fffffffffffffP+1023;
-    public static final double MIN_VALUE;
-    //@ axiom MIN_VALUE == 0x0.0000000000001P-1022;
+    public static final double MAX_VALUE = 0x1.fffffffffffffP+1023;
+    public static final double MIN_VALUE = 0x0.0000000000001P-1022;
     
     // FIXME - the following axiom causes simple assertions to time out
     // @ axiom isFinite(MAX_VALUE) && isFinite(MIN_VALUE);

--- a/specs/java/lang/Double.jml
+++ b/specs/java/lang/Double.jml
@@ -74,7 +74,10 @@ public /*@ pure @*/ final class Double extends Number implements Comparable {
     public static final double NaN;
 
     public static final double MAX_VALUE;
+    //@ axiom MAX_VALUE == 0x1.fffffffffffffP+1023;
     public static final double MIN_VALUE;
+    //@ axiom MIN_VALUE == 0x0.0000000000001P-1022;
+    
     // FIXME - the following axiom causes simple assertions to time out
     // @ axiom isFinite(MAX_VALUE) && isFinite(MIN_VALUE);
 
@@ -122,7 +125,7 @@ public /*@ pure @*/ final class Double extends Number implements Comparable {
         throws NumberFormatException;
 
     //@ public normal_behavior
-    //@   ensures \result <==> (!isNaN(v) && !isInfinite(v));
+    //@   ensures \result <==> ( v <= MAX_VALUE && v >= -MAX_VALUE);
     //@ pure helper
     public static boolean isFinite(double v);
     

--- a/specs/java/lang/Double.jml
+++ b/specs/java/lang/Double.jml
@@ -73,6 +73,7 @@ public /*@ pure @*/ final class Double extends Number implements Comparable {
 
     public static final double MAX_VALUE = 0x1.fffffffffffffP+1023;
     public static final double MIN_VALUE = 0x0.0000000000001P-1022;
+    public static final double MIN_NORMAL = 0x1.0p-1022;
     
     // FIXME - the following axiom causes simple assertions to time out
     // @ axiom isFinite(MAX_VALUE) && isFinite(MIN_VALUE);

--- a/specs/java/lang/Math.jml
+++ b/specs/java/lang/Math.jml
@@ -77,7 +77,7 @@ public /*@ pure @*/ final class Math {
       @   requires isNegativeZero(a);
       @   ensures isNegativeZero(\result);
       @ also
-      @   requires isFinite(a);
+      @   requires Double.isFinite(a);
       @   ensures (* result within 1 ulp of exact result *);
       @   ensures \result <= 1.0 && \result >= -1.0;
       @ |}
@@ -92,7 +92,7 @@ public /*@ pure @*/ final class Math {
       @   requires a == 0.0;  // positive or negative zero
       @   ensures \result == 1.0;
       @ also
-      @   requires isFinite(a);
+      @   requires Double.isFinite(a);
       @   ensures (* result within 1 ulp of exact result *);
       @   ensures \result <= 1.0 && \result >= -1.0;
       @ |}
@@ -113,7 +113,7 @@ public /*@ pure @*/ final class Math {
       @   requires isNegativeZero(a);
       @   ensures isNegativeZero(\result);
       @ also
-      @   requires isFinite(a);
+      @   requires Double.isFinite(a);
       @   ensures (* result within 1 ulp of exact result *);
       @ |}
       @*/
@@ -133,7 +133,7 @@ public /*@ pure @*/ final class Math {
       @   requires isNegativeZero(a);
       @   ensures isNegativeZero(\result);
       @ also
-      @   requires isFinite(a) && a <= 1 && a >= -1;
+      @   requires Double.isFinite(a) && a <= 1 && a >= -1;
       @   ensures -PI/2 <= \result && \result <= PI/2;
       @   ensures (* result within 1 ulp of exact result *);
       @ |}
@@ -194,7 +194,7 @@ public /*@ pure @*/ final class Math {
       @   requires a == Double.NEGATIVE_INFINITY;
       @   ensures isPositiveZero(\result);
       @ also
-      @   requires isFinite(a);
+      @   requires Double.isFinite(a);
       @   ensures (* result within 1 ulp of exact result *);
       @ |}
       @*/
@@ -326,8 +326,8 @@ public /*@ pure @*/ final class Math {
       @   requires a == rint(a);
       @   ensures \result == a;
       @ also
-      @   requires isFinite(a) && a != 0.0;
-      @   ensures isFinite(a);
+      @   requires Double.isFinite(a) && a != 0.0;
+      @   ensures Double.isFinite(a);
       @   ensures \result == rint(\result);
       @   ensures a <= \result;
       @   ensures (\forall double d; a < d & d < \result; rint(d) != d);
@@ -347,8 +347,8 @@ public /*@ pure @*/ final class Math {
       @   requires a == rint(a);
       @   ensures \result == a;
       @ also
-      @   requires isFinite(a) && a != 0.0;
-      @   ensures isFinite(\result);
+      @   requires Double.isFinite(a) && a != 0.0;
+      @   ensures Double.isFinite(\result);
       @   ensures \result == rint(\result);
       @   ensures \result <= a;
       @   ensures (\forall double d; \result < d && d < a; rint(d) != d);
@@ -364,8 +364,8 @@ public /*@ pure @*/ final class Math {
       @   requires Double.isNaN(a);
       @   ensures Double.isNaN(\result);
       @ also
-      @   requires isFinite(a) && a != 0.0;
-      @   ensures isFinite(\result);
+      @   requires Double.isFinite(a) && a != 0.0;
+      @   ensures Double.isFinite(\result);
       @   ensures (* \result is mathematical integer closest to a *);
       @ |}
       @*/
@@ -753,7 +753,7 @@ public /*@ pure @*/ final class Math {
       @   requires Double.isNaN(d);
       @   ensures Double.isNaN(\result);
       @ also
-      @   requires !isFinite(d);
+      @   requires !Double.isFinite(d);
       @   ensures \result == Double.POSITIVE_INFINITY;
       @ also
       @   requires d == 0.0;
@@ -762,7 +762,7 @@ public /*@ pure @*/ final class Math {
       @   requires abs(d) == Double.MAX_VALUE;
       @   ensures \result == pow(2, 971);
       @ also 
-      @   requires isFinite(d);
+      @   requires Double.isFinite(d);
       @   ensures Double.MIN_VALUE <= \result && \result <= pow(2, 971);
       @ |}
       @*/
@@ -774,7 +774,7 @@ public /*@ pure @*/ final class Math {
       @   requires Float.isNaN(f);
       @   ensures Float.isNaN(\result);
       @ also
-      @   requires !isFinite(f);
+      @   requires !Double.isFinite(f);
       @   ensures \result == Float.POSITIVE_INFINITY;
       @ also
       @   requires f == 0.0;
@@ -783,7 +783,7 @@ public /*@ pure @*/ final class Math {
       @   requires abs(f) == Float.MAX_VALUE;
       @   ensures \result == pow(2, 104);
       @ also 
-      @   requires isFinite(f);
+      @   requires Double.isFinite(f);
       @   ensures Float.MIN_VALUE <= \result && \result <= pow(2, 104);
       @ |}
       @*/
@@ -837,10 +837,10 @@ public /*@ pure @*/ final class Math {
       @   requires Double.isNaN(x);
       @   ensures Double.isNaN(\result);
       @ also
-      @   requires !isFinite(x) || x == 0.0;
+      @   requires !Double.isFinite(x) || x == 0.0;
       @   ensures \result == x;
       @ also
-      @   requires isFinite(x);
+      @   requires Double.isFinite(x);
       @   ensures (* result within 2.5 ulps of exact result *);
       @ |}
       @*/
@@ -852,13 +852,13 @@ public /*@ pure @*/ final class Math {
       @   requires Double.isNaN(x);
       @   ensures Double.isNaN(\result);
       @ also
-      @   requires !isFinite(x);
+      @   requires !Double.isFinite(x);
       @   ensures \result == Double.POSITIVE_INFINITY;
       @ also
       @   requires x == 0.0;
       @   ensures \result == 1.0;
       @ also
-      @   requires isFinite(x);
+      @   requires Double.isFinite(x);
       @   ensures (* result within 2.5 ulps of exact result *);
       @ |}
       @*/
@@ -879,7 +879,7 @@ public /*@ pure @*/ final class Math {
       @   requires x == Double.NEGATIVE_INFINITY;
       @   ensures \result == -1.0;
       @ also
-      @   requires isFinite(x);
+      @   requires Double.isFinite(x);
       @   ensures abs(\result) <= 1.0;
       @   ensures (* result within 2.5 ulps of exact result *);
       @ |}
@@ -889,13 +889,13 @@ public /*@ pure @*/ final class Math {
     // new for Java 5
     /*@ public normal_behavior
       @ {|
-      @   requires !isFinite(x) || !isFinite(y);
+      @   requires !Double.isFinite(x) || !Double.isFinite(y);
       @   ensures \result == Double.POSITIVE_INFINITY;
       @ also
       @   requires Double.isNaN(x) || Double.isNaN(y);
       @   ensures Double.isNaN(\result);
       @ also
-      @   requires isFinite(x) && isFinite(y);
+      @   requires Double.isFinite(x) && Double.isFinite(y);
       @   ensures (* result within 1 ulp of exact result *);
       @ |}
       @*/
@@ -916,7 +916,7 @@ public /*@ pure @*/ final class Math {
       @   requires x == 0.0;
       @   ensures \result == x;
       @ also
-      @   requires isFinite(x);
+      @   requires Double.isFinite(x);
       @   ensures (* result within 1 ulp of exact result *);
       @   ensures -1.0 <= \result;
       @ |}
@@ -938,7 +938,7 @@ public /*@ pure @*/ final class Math {
       @   requires x == 0.0;
       @   ensures \result == x;
       @ also
-      @   requires isFinite(x);
+      @   requires Double.isFinite(x);
       @   ensures (* result within 1 ulp of exact result *);
       @ |}
       @*/
@@ -1047,19 +1047,19 @@ public /*@ pure @*/ final class Math {
       @   requires start == Double.MIN_VALUE && signum(direction) == -1.0;
       @   ensures \result == Double.NEGATIVE_INFINITY;
       @ also
-      @   requires start != direction && isFinite(start)
+      @   requires start != direction && Double.isFinite(start)
       @         && !Double.isNaN(direction) && signum(direction) == -1.0;
       @   ensures \result < start;
       @   ensures (* result is the number adjacent to start in the 
       @              negative direction *);
       @ also
-      @   requires start != direction && isFinite(start)
+      @   requires start != direction && Double.isFinite(start)
       @         && !Double.isNaN(direction) && signum(direction) == 1.0;
       @   ensures start < \result;
       @   ensures (* result is the number adjacent to start in the 
       @              positive direction *);
       @ also
-      @   requires start != direction && isFinite(start)
+      @   requires start != direction && Double.isFinite(start)
       @         && !Double.isNaN(direction) && signum(direction) == 0.0;
       @   ensures \result == start;
       @ |}
@@ -1093,19 +1093,19 @@ public /*@ pure @*/ final class Math {
       @   requires start == Float.MIN_VALUE && signum(direction) == -1.0;
       @   ensures \result == Float.NEGATIVE_INFINITY;
       @ also
-      @   requires start != direction && isFinite(start)
+      @   requires start != direction && Double.isFinite(start)
       @         && !Double.isNaN(direction) && signum(direction) == -1.0;
       @   ensures \result < start;
       @   ensures (* result is the number adjacent to start in the 
       @              negative direction *);
       @ also
-      @   requires start != direction && isFinite(start)
+      @   requires start != direction && Double.isFinite(start)
       @         && !Double.isNaN(direction) && signum(direction) == 1.0;
       @   ensures start < \result;
       @   ensures (* result is the number adjacent to start in the 
       @              positive direction *);
       @ also
-      @   requires start != direction && isFinite(start)
+      @   requires start != direction && Double.isFinite(start)
       @         && !Double.isNaN(direction) && signum(direction) == 0.0;
       @   ensures \result == start;
       @ |}
@@ -1185,14 +1185,9 @@ public /*@ pure @*/ final class Math {
         public static model pure function boolean isNegativeZero(float a) {
           return java.lang.Float.isNegativeZero(a);
         }
-    
-        public static model pure function boolean isFinite(double a) {
-          return Double.NEGATIVE_INFINITY < a && 
-                 a < Double.POSITIVE_INFINITY;
-        }
 
         public static model pure function boolean isFiniteOdd(double a) {
-          if ((a - 2.0 * floor(a / 2.0)) == 1.0 && isFinite(a)) {
+          if ((a - 2.0 * floor(a / 2.0)) == 1.0 && Double.isFinite(a)) {
             return true;
           } else {
             return false;
@@ -1200,7 +1195,7 @@ public /*@ pure @*/ final class Math {
         }
      
        public static model pure function boolean isFiniteEven(double a) {
-          if (IEEEremainder(a, 2.0) == 0.0 && isFinite(a)) {
+          if (IEEEremainder(a, 2.0) == 0.0 && Double.isFinite(a)) {
             return true;
           } else {
             return false;


### PR DESCRIPTION
Here I partially fix some issues involving OpenJML's verification of Math method behaviors on finite inputs. These issues were caused in part by problems with the Double.isFinite method and the Math.isFinite method. I remove the Math.isFinite method and I replace the Double.isFinite specification so that it avoids comparisons with infinities and NaN, which currently have issues.